### PR TITLE
Fixing Various Docker Compose Issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres
     environment:
-      - POSTGRES_DB=moviegeek
+      - POSTGRES_DB=moviegeeks
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   web:
     build: .
-    command: bash -c "python manage.py makemigrations && python manage.py migrate --run-syncdb && python populate_moviegeek.py && python populate_ratings.py python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "python manage.py makemigrations && python manage.py migrate --run-syncdb && python populate_moviegeek.py && python populate_ratings.py && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
The Docker Compose environment variable `PG_DATABASE` is mismatched (`moviegeek` should be `moviegeeks`), which causes an immediate failure on database migrations. Likewise, this adds the missing AND-IF (`&&`) operator after the ratings population in `command`, which now starts the web listener.